### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   - /.*/
 language: node_js
 node_js:
-- node
+- '11'
 cache:
   directories:
   - "$HOME/.npm"


### PR DESCRIPTION
Enforce use of older node_js version, because node_sass does not work with node 12 yet.