### PR TITLE
Feature/rc 132 links

### DIFF
--- a/app/components/links/copy/description.md
+++ b/app/components/links/copy/description.md
@@ -3,5 +3,10 @@ Copy Link bezeichnet einen Link im Fließtext im Content.
 ### Utilities  
 Weitere Textauszeichnungen über [ds-utility-Klassen](#group-utilities-component-typography-utilities) möglich.
 
+### Code
+Das Linkstyling kann via Klasse `.ds-copy-link` auf hardcoded Links oder als mixin mit `@include ds-copy-link` auf wysiwyg content gesetzt werden.
+
 ### Styles  
-geerbt von Copy Text
+- Links haben den Schriftschnitt `medium`, `letter-spacing: 0.5px` und werden initial __nicht__ unterstrichen.
+- Bei Hover bekommen die Links eine `text-decoration: underline`
+- Schriftgröße wird geerbt von Copy Text. 

--- a/app/components/links/links.scss
+++ b/app/components/links/links.scss
@@ -1,14 +1,17 @@
-.ds-copy-link {
+@mixin ds-copy-link {
     color: $color-corporate-green-dark;
+    font-weight: 500;
     letter-spacing: 0.5px;
-    text-decoration: underline;
+    text-decoration: none;
 
     &:hover,
     &:focus {
-        background: rgba($color-corporate-green, 0.2);
-        color: $color-text;
-        text-decoration: none;
+        text-decoration: underline;
     }
+}
+
+.ds-copy-link {
+    @include ds-copy-link;
 }
 
 /* if the headline is the link */

--- a/app/data.json
+++ b/app/data.json
@@ -24,7 +24,7 @@
         "show_version": true,
         "max_width": null,
         "titles": {
-            "library_title": "v5.3.5",
+            "library_title": "v5.4.0",
             "pages_title": "Übersicht",
             "components_title": "Komponenten"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chefkoch-design-system",
-  "version": "5.3.5",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chefkoch-design-system",
-  "version": "5.3.5",
+  "version": "5.4.0",
   "description": "Chefkoch Design System",
   "repository": "https://github.com/chefkoch-dev/design-system.git",
   "author": "Team Geist/Team Funkytown Avengers",


### PR DESCRIPTION
Um für die Breadcrumbs in recipe-amp jetzt nicht das neue copy-link Styling faken zu müssen und sie dann im nächsten Sprint wieder anzufassen, habe ich die Story RC-132 vorgezogen. Absoluter nobrainer.