### PR TITLE
Bugfix/flexible recipe meta

### DIFF
--- a/app/components/recipe/recipe-meta.scss
+++ b/app/components/recipe/recipe-meta.scss
@@ -2,7 +2,6 @@
 ----------------------------------- */
 
 .ds-recipe-meta {
-    display: flex;
     margin-left: -2px;
 
     > span {

--- a/app/components/recipe/recipe-meta.scss
+++ b/app/components/recipe/recipe-meta.scss
@@ -13,10 +13,12 @@
         align-items: center;
         font-size: $fontsize-tiny;
         height: $unit * 2;
+        margin-bottom: $unit / 2;
         margin-right: $unit / 2;
         padding: $unit / 2 $unit;
 
         @include media-breakpoint-from(m) {
+            margin-bottom: $unit;
             margin-right: $unit;
         }
     }

--- a/app/components/recipe/recipe-meta/markup.html
+++ b/app/components/recipe/recipe-meta/markup.html
@@ -2,41 +2,41 @@
     <div class="ds-box ds-col-12 ds-col-m-6">
         <h4>Ausprägungen</h4>
         <small class="ds-recipe-meta">
-            <span class="ds-recipe-preptime">
+            <span>
                 <i class="material-icons">access_time</i>
                 5 min.
             </span>
-            <span class="ds-recipe-difficulty">
+            <span>
                 <i class="material-icons">signal_cellular_alt</i>
                 <span>simpel</span>
             </span>
-            <span class="ds-recipe-date">
+            <span>
                 <i class="material-icons">date_range</i>
                 15.01.2019
             </span>
         </small>
         <br/>
         <small class="ds-recipe-meta">
-            <span class="ds-recipe-preptime">
+            <span>
                 <i class="material-icons">access_time</i>
                 30 min.
             </span>
-            <span class="ds-recipe-difficulty">
+            <span>
                 <i class="material-icons">signal_cellular_alt</i>
                 normal
             </span>
-            <span class="ds-recipe-date">
+            <span>
                 <i class="material-icons">date_range</i>
                 15.01.19
             </span>
         </small>
         <br/>
         <small class="ds-recipe-meta">
-            <span class="ds-recipe-preptime">
+            <span>
                 <i class="material-icons">access_time</i>
                 120 min.
             </span>
-            <span class="ds-recipe-difficulty">
+            <span>
                 <i class="material-icons">signal_cellular_alt</i>
                 pfiffig
             </span>
@@ -64,15 +64,15 @@
         <p class="recipe-text" style="max-width: 300px;">Nur das Beste für jeden Bacon Lover. Bacon Stripes vom
             Feinsten, yum!</p>
         <small class="ds-recipe-meta">
-            <span class="ds-recipe-preptime">
+            <span>
                 <i class="material-icons">access_time</i>
                 5 min.
             </span>
-            <span class="ds-recipe-difficulty">
+            <span>
                 <i class="material-icons">signal_cellular_alt</i>
                 simpel
             </span>
-            <span class="ds-recipe-date">
+            <span>
                 <i class="material-icons">date_range</i>
                 15.01.2019
             </span>

--- a/app/data.json
+++ b/app/data.json
@@ -24,7 +24,7 @@
         "show_version": true,
         "max_width": null,
         "titles": {
-            "library_title": "v6.3.0",
+            "library_title": "v6.3.1",
             "pages_title": "Übersicht",
             "components_title": "Komponenten"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chefkoch-design-system",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chefkoch-design-system",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Chefkoch Design System",
   "repository": "https://github.com/chefkoch-dev/design-system.git",
   "author": "Team Geist/Team Funkytown Avengers",


### PR DESCRIPTION
Die Rezept-Meta Informationen brechen momentan nicht um. Dieser PR behebt das, indem `display: flex` weggenommen wird. Aus dem `small` mit der Klasse `ds-recipe-meta` wird somit ein `display: block`, und die enthaltenen Elemente brechen um.
Natürlich wäre auch ein `flex-wrap: wrap` möglich gewesen, aber mehr CSS.

Außerdem habe ich Abstände nach unten hinzugefügt, die auf der RSEL noch überschrieben werden müssen.