### PR TITLE
RI-1083: set font-size and width of material icon container to avoid cls

### DIFF
--- a/app/components/icons/material-icons.scss
+++ b/app/components/icons/material-icons.scss
@@ -1,0 +1,7 @@
+// RI-1083: set size and with to all icons per default to 24px to avoid cls
+/* stylelint-disable all */
+.material-icons {
+    font-size: 24px;
+    width: 1em;
+}
+/* stylelint-enable all */

--- a/components/dsy-base.scss
+++ b/components/dsy-base.scss
@@ -17,3 +17,4 @@
 @import "../app/components/colors/colors";
 @import "../app/components/spacings/spacings";
 @import "../app/components/links/links";
+@import "../app/components/icons/material-icons";


### PR DESCRIPTION
Wir haben festgestellt dass die Material Icons einen Content Layout Shift (CLS) verursachen. Das CSS und die Font werden von Google nachgeladen. Das hat zur Folge dass zum einen "font-size: 24px" und die Schrift selber erst später kommen. Wenn dann alles geladen ist, springt der Inhalt um den dann benötigten Platz. Mit diesem Fix wird der Platz von vornherein 
reserviert.

Hier das Icon Font CSS welches nachgeladen wird:
https://fonts.googleapis.com/css?family=Material+Icons

In diesem PR ist die Versionsnummer noch nicht gesetzt, da ich nicht weiss wann ihr welche Version releasen wollt. Es gibt ja schon einen PR für die v9.14.0.

Entweder das hier wird dann die v9.14.1 oder ihr pickt euch diese Änderung raus packt es in eins der nächsten Releases.